### PR TITLE
Fix git access token not being sent in header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,18 @@ repositories {
     jcenter()
 }
 
-mainClassName = 'link.infra.packwiz.installer.bootstrap.Main'
+File testProjectDirectory = rootProject.getBuildDir().toPath().resolve("test-project").toFile()
+testProjectDirectory.mkdirs()
+
+application {
+    mainClassName = 'link.infra.packwiz.installer.bootstrap.Main'
+
+    // Change the working directory for the run task. Here is an example:
+    tasks.run.workingDir = testProjectDirectory
+}
 
 jar {
     manifest {
-        attributes(
-            'Main-Class': 'link.infra.packwiz.installer.bootstrap.Main'
-        )
+        attributes('Main-Class': 'link.infra.packwiz.installer.bootstrap.Main')
     }
 }

--- a/src/main/java/link/infra/packwiz/installer/bootstrap/Bootstrap.java
+++ b/src/main/java/link/infra/packwiz/installer/bootstrap/Bootstrap.java
@@ -223,10 +223,9 @@ public class Bootstrap {
 		Release rel = new Release();
 
 		URL url = new URL(updateURL);
-		if (accessToken != null) {
-			url = new URL(updateURL + "?access_token=" + accessToken);
-		}
 		URLConnection conn = url.openConnection();
+
+		addAuthorizationHeader(conn);
 		// 30 second read timeout
 		conn.setReadTimeout(30 * 1000);
 		InputStream in;
@@ -288,11 +287,9 @@ public class Bootstrap {
 
 	private static void downloadUpdate(String downloadURL, String assetURL, String path) throws IOException {
 		URL url = new URL(downloadURL);
-		if (accessToken != null) {
-			// Authenticated downloads use the assetURL
-			url = new URL(assetURL + "?access_token=" + accessToken);
-		}
 		URLConnection conn = url.openConnection();
+
+		addAuthorizationHeader(conn);
 		conn.addRequestProperty("Accept", "application/octet-stream");
 		// 30 second read timeout
 		conn.setReadTimeout(30 * 1000);
@@ -304,6 +301,13 @@ public class Bootstrap {
 		}
 		Files.copy(in, Paths.get(path), StandardCopyOption.REPLACE_EXISTING);
 		in.close();
+	}
+
+	private static void addAuthorizationHeader(URLConnection conn) {
+		if (accessToken != null) {
+			// Authenticated downloads use the assetURL
+			conn.addRequestProperty("Authorization", accessToken);
+		}
 	}
 
 }

--- a/src/main/java/link/infra/packwiz/installer/bootstrap/Bootstrap.java
+++ b/src/main/java/link/infra/packwiz/installer/bootstrap/Bootstrap.java
@@ -290,7 +290,6 @@ public class Bootstrap {
 	private static void downloadUpdate(String downloadURL, String assetURL, String path) throws IOException {
 		URL url = new URL(downloadURL);
 		if (accessToken != null) {
-			//url = new URL(downloadURL + "?access_token=" + accessToken);
 			// Authenticated downloads use the assetURL
 			url = new URL(assetURL + "?access_token=" + accessToken);
 		}

--- a/src/main/java/link/infra/packwiz/installer/bootstrap/Bootstrap.java
+++ b/src/main/java/link/infra/packwiz/installer/bootstrap/Bootstrap.java
@@ -261,11 +261,11 @@ public class Bootstrap {
 			}
 			JsonObject asset = assetValue.asObject();
 			JsonValue name = asset.get("name");
-			if (name == null || !name.isString()) {
-				throw new GithubException("Asset name cannot be found");
-			}
 			if (!name.asString().equalsIgnoreCase(JAR_NAME)) {
 				continue;
+			}
+			if (name == null || !name.isString()) {
+				throw new GithubException("Asset name cannot be found");
 			}
 			JsonValue downloadURL = asset.get("browser_download_url");
 			if (downloadURL == null || !downloadURL.isString()) {

--- a/src/main/java/link/infra/packwiz/installer/bootstrap/Bootstrap.java
+++ b/src/main/java/link/infra/packwiz/installer/bootstrap/Bootstrap.java
@@ -280,7 +280,7 @@ public class Bootstrap {
 	private static String getStringProperty(String property, JsonObject obj, String displayName) throws GithubException {
 		JsonValue value = obj.get(property);
 		if (value == null || !value.isString()) {
-			throw new GithubException("$displayName (" + property + ") cannot be found");
+			throw new GithubException(displayName + " (" + property + ") cannot be found");
 		}
 		return value.asString();
 	}


### PR DESCRIPTION
I found a bug in latest (v0.0.3).  Github API began complaining about needing the tokens to be passed in the request header, which of course, stops packwiz dead in its tracks if you've passed a token in.

Typically, these authorization header tokens are done with "Authorization" as the key name, which worked when I tested it.

In addition, I did some minor cleanup for readability and maintainability.

Last, but not least, I setup the `application` Gradle plugin to run results in a new build subfolder `<gradle_build_dir>/test-project` where the default is `<project_dir>/build/test-project`.  