### PR TITLE
Automated Release - Java 8 Compatibilty

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+on:
+  push:
+    tags: '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: 8
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v5
+      with:
+        gradle-version: '8.14'
+    - name: Build with Gradle
+      run: gradle shadowjar
+    - run: git log $(git describe --tags --abbrev=0 HEAD~1)..HEAD --oneline > changelog.txt
+    - uses: softprops/action-gh-release@v2
+      with:
+        make_latest: true
+        body_path: changelog.txt
+        files: build/libs/*

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'com.gradleup.shadow' version '9.3.1'
+    id 'com.gradleup.shadow' version '8.3.9'
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'com.github.johnrengelman.shadow' version '5.0.0'
+    id 'com.gradleup.shadow' version '9.3.1'
 }
 
 dependencies {
@@ -11,14 +11,14 @@ dependencies {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 File testProjectDirectory = rootProject.getBuildDir().toPath().resolve("test-project").toFile()
 testProjectDirectory.mkdirs()
 
 application {
-    mainClassName = 'link.infra.packwiz.installer.bootstrap.Main'
+    mainClass = 'link.infra.packwiz.installer.bootstrap.Main'
 
     // Change the working directory for the run task. Here is an example:
     tasks.run.workingDir = testProjectDirectory


### PR DESCRIPTION
The instructions for use of this jar say to use %INST_JAVA% to launch it, which may be as old as java 8, but the jar file distributed requires a newer version of java. The automated build and release in this PR uses java 8 to build the jar, fixing the compatibility issue. The build.gradle file was also updated for the newest java 8 compatible version of gradle and shadow jar.